### PR TITLE
Allow custom privacy settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,14 +172,12 @@
             <div class="form-group">
                 <input type="text" name="description" id="videoDescription" class="form-control" placeholder="Video description" value=""></input>
             </div>
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox" id="upgrade_to_1080" name="upgrade_to_1080"> Upgrade to 1080 </input>
-                </label>
+            <div class="form-group">
+                <input type="text" name="privacy" id="videoPrivacy" class="form-control" value="anybody"></input>
             </div>
             <div class="checkbox">
                 <label>
-                    <input type="checkbox" id="make_private" name="make_private"> Make Private </input>
+                    <input type="checkbox" id="upgrade_to_1080" name="upgrade_to_1080"> Upgrade to 1080 </input>
                 </label>
             </div>
           </div>
@@ -226,7 +224,7 @@
             ;(new VimeoUpload({
                 name: document.getElementById('videoName').value,
                 description: document.getElementById('videoDescription').value,
-                private: document.getElementById('make_private').checked,
+                privacy: document.getElementById('videoPrivacy').value,
                 file: files[0],
                 token: document.getElementById('accessToken').value,
                 upgrade_to_1080: document.getElementById('upgrade_to_1080').checked,

--- a/vimeo-upload.js
+++ b/vimeo-upload.js
@@ -109,6 +109,7 @@
         api_url: 'https://api.vimeo.com',
         name: 'Default name',
         description: 'Default description',
+        privacy: 'anybody',
         contentType: 'application/octet-stream',
         token: null,
         file: {},
@@ -161,7 +162,7 @@
         this.videoData = {
             name: (opts.name > '') ? opts.name : defaults.name,
             description: (opts.description > '') ? opts.description : defaults.description,
-            'privacy.view': opts.private ? 'nobody' : 'anybody'
+            'privacy.view': (opts.privacy > '') ? opts.privacy : defaults.privacy
         }
 
         if (!(this.url = opts.url)) {


### PR DESCRIPTION
I used this lib, but had to follow up every upload with a second call to set my videos privacy to 'disable'. We are using Vimeo to embed videos, so that was the setting we needed.

Eventually I enabled 'Private Mode' on Vimeo, which actually caused uploads to fail because this library first tried to set two options which were not supported in that mode. That drove me to finally update this and make it work for more uses cases, as requested in #14.

I tested this with my app and it worked fine, I didn't test the updates to `index.html` but they are pretty simple.
